### PR TITLE
refactor!: use vim.keymap.set instead of vim.api.nvim_set_keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ This plugin [already exists](https://github.com/svermeulen/vim-cutlass) in vimsc
 
 ## ⚡️ Requirements
 
-- Neovim >= 0.5.0
+- Neovim >= 0.7.0
+
+(For Neovim 0.5 compatibility, you can use the [compat-0.5](https://github.com/gbprod/cutlass.nvim/tree/compat-0.5) branch)
 
 ## 📦 Installation
 

--- a/lua/cutlass.lua
+++ b/lua/cutlass.lua
@@ -18,7 +18,7 @@ local function with_defaults(options)
 end
 
 local keymap_opts = { noremap = true, silent = true }
-local map = vim.api.nvim_set_keymap
+local map = vim.keymap.set
 
 function cutlass.setup(options)
   cutlass.options = with_defaults(options or {})


### PR DESCRIPTION
BREAKING CHANGE: Drop compatibility with nvim < 0.7.0